### PR TITLE
Generalize Plotting Capability

### DIFF
--- a/R/plotManhattan.R
+++ b/R/plotManhattan.R
@@ -60,7 +60,7 @@ function(bedfile, chrom=NULL,chromstart=NULL,chromend=NULL,pvalues,genome=NULL,c
         columber = 1
       }
 
-      rowsofinterest = which(bedfile[,1] == chromoffsets[i,1])
+      rowsofinterest = which(as.character(bedfile[,1]) == as.character(chromoffsets[i,1]))
       bedfile[rowsofinterest,2] =  bedfile[rowsofinterest,2] + chromoffsets[i,3]
       columbers[rowsofinterest] = columber
     }

--- a/R/sortChrom.R
+++ b/R/sortChrom.R
@@ -9,7 +9,7 @@ function(genome)
   data_nochr[,1] = gsub("chr", "", data_nochr[,1])
   
   # sort the data
-  numericvalues = suppressWarnings(as.numeric(data_nochr$V1))
+  numericvalues = suppressWarnings(as.numeric(data_nochr[,1]))
   
   # sort the numeric ones
   data_nochr_num = data_nochr[which(is.na(numericvalues) == FALSE),]


### PR DESCRIPTION
Minor tweaks to generate Manhattan plots for more general datasets. Cast chromosome names as characters when comparing rows, and removed assumption that chromosome column was called 'V1'.